### PR TITLE
lemonades: Add assert for OnePlus 8T and 9R

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -19,6 +19,9 @@
 
 DEVICE_PATH := device/oneplus/lemonades
 
+# Assert
+TARGET_OTA_ASSERT_DEVICE := OnePlus9R,OnePlus8T
+
 # Bluetooth
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(DEVICE_PATH)/bluetooth/include
 


### PR DESCRIPTION
* In order to add support for existing 8T recoveries.